### PR TITLE
Add code to prepare.yml to install init on Debian images

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,3 +8,29 @@
     - name: Install boto3
       pip:
         name: boto3
+
+# If a systemd host lacks the file /sbin/init, then testinfra
+# currently misidentifies it as using SysV.  The relevant code can be
+# viewed here:
+# https://github.com/philpep/testinfra/blob/master/testinfra/modules/service.py#L51-L63.
+#
+# The Debian 9 and Debian 10 Docker images that we are using suffer
+# from this issue; therefore, we need to install the init package as a
+# workaround.  Any real (non-Docker) host will have this package
+# installed anyway.
+#
+# This is a known testinfra issue.  See
+# https://github.com/philpep/testinfra/issues/416 for more details.
+- name: Group hosts by OS distribution
+  hosts: all
+  tasks:
+    - name: Group hosts by OS distribution
+      group_by:
+        key: os_{{ ansible_facts['distribution'] }}
+- name: Install init (Debian)
+  hosts: os_Debian
+  tasks:
+    - name: Install init (Debian)
+      package:
+        name:
+          - init


### PR DESCRIPTION
This is a workaround for the fact that testinfra currently misidentifies the init system on these hosts.

See philpep/testinfra#416 for more details.