### PR TITLE
Modify Apache configuration to proxy websocket connections

### DIFF
--- a/files/guacamole_httpd_config
+++ b/files/guacamole_httpd_config
@@ -11,7 +11,7 @@
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
 
-    SSLEngine on
+    SSLEngine On
 
     SSLCertificateFile /var/guacamole/httpd/ssl/self.cert
     SSLCertificateKeyFile /var/guacamole/httpd/ssl/self-ssl.key
@@ -22,13 +22,13 @@
         GssapiCredStore keytab:/etc/krb5_http.keytab
         GssapiSSLonly On
         GssapiUseSessions On
-        Session on
+        Session On
         SessionCookieName gssapi_session path=/;httponly;secure;
 
         require pam-account guacamole
 
-        ProxyPass http://localhost/guacamole/
-        ProxyPassReverse http://localhost/guacamole/
+        ProxyPass http://localhost/guacamole flushpackets=on
+        ProxyPassReverse http://localhost/guacamole
 
         RequestHeader set REMOTE_USER guacuser
     </Location>
@@ -39,13 +39,13 @@
         GssapiCredStore keytab:/etc/krb5_http.keytab
         GssapiSSLonly On
         GssapiUseSessions On
-        Session on
-        SessionCookieName gssapi_session path=/admin/;httponly;secure;
+        Session On
+        SessionCookieName gssapi_session path=/admin;httponly;secure;
 
         require pam-account guacamole-admin
 
-        ProxyPass http://localhost/guacamole/
-        ProxyPassReverse http://localhost/guacamole/
+        ProxyPass http://localhost/guacamole flushpackets=on
+        ProxyPassReverse http://localhost/guacamole
 
         RequestHeader set REMOTE_USER guacadmin
     </Location>

--- a/files/guacamole_httpd_config
+++ b/files/guacamole_httpd_config
@@ -27,8 +27,9 @@
 
         require pam-account guacamole
 
-        ProxyPass http://localhost/guacamole flushpackets=on
-        ProxyPassReverse http://localhost/guacamole
+        ProxyPass http://localhost/guacamole/ flushpackets=on
+        ProxyPassReverse http://localhost/guacamole/
+        ProxyPassReverseCookiePath /guacamole/ /
 
         RequestHeader set REMOTE_USER guacuser
     </Location>
@@ -50,19 +51,20 @@
         RequestHeader set REMOTE_USER guacuser
     </Location>
 
-    <Location /admin>
+    <Location /admin/>
         AuthType GSSAPI
         AuthName "FreeIPA Kerberos Login for Guacamole Administrators"
         GssapiCredStore keytab:/etc/krb5_http.keytab
         GssapiSSLonly On
         GssapiUseSessions On
         Session On
-        SessionCookieName gssapi_session path=/admin;httponly;secure;
+        SessionCookieName gssapi_session path=/admin/;httponly;secure;
 
         require pam-account guacamole-admin
 
-        ProxyPass http://localhost/guacamole flushpackets=on
-        ProxyPassReverse http://localhost/guacamole
+        ProxyPass http://localhost/guacamole/ flushpackets=on
+        ProxyPassReverse http://localhost/guacamole/
+        ProxyPassReverseCookiePath /guacamole/ /admin/
 
         RequestHeader set REMOTE_USER guacadmin
     </Location>

--- a/files/guacamole_httpd_config
+++ b/files/guacamole_httpd_config
@@ -33,7 +33,27 @@
         RequestHeader set REMOTE_USER guacuser
     </Location>
 
-    <Location /admin/>
+    <Location /websocket-tunnel>
+        # AuthType GSSAPI
+        # AuthName "FreeIPA Kerberos Login for Guacamole Users"
+        # GssapiCredStore keytab:/etc/krb5_http.keytab
+        # GssapiSSLonly On
+        # GssapiUseSessions On
+        # Session On
+        # SessionCookieName gssapi_session path=/admin;httponly;secure;
+
+        # require pam-account guacamole-admin
+
+        Order allow,deny
+        Allow from all
+
+        ProxyPass ws://localhost/guacamole/websocket-tunnel
+        ProxyPassReverse ws://localhost/guacamole/websocket-tunnel
+
+        # RequestHeader set REMOTE_USER guacadmin
+    </Location>
+
+    <Location /admin>
         AuthType GSSAPI
         AuthName "FreeIPA Kerberos Login for Guacamole Administrators"
         GssapiCredStore keytab:/etc/krb5_http.keytab
@@ -48,5 +68,25 @@
         ProxyPassReverse http://localhost/guacamole
 
         RequestHeader set REMOTE_USER guacadmin
+    </Location>
+
+    <Location /websocket-tunnel>
+        # AuthType GSSAPI
+        # AuthName "FreeIPA Kerberos Login for Guacamole Administrators"
+        # GssapiCredStore keytab:/etc/krb5_http.keytab
+        # GssapiSSLonly On
+        # GssapiUseSessions On
+        # Session On
+        # SessionCookieName gssapi_session path=/admin;httponly;secure;
+
+        # require pam-account guacamole-admin
+
+        Order allow,deny
+        Allow from all
+
+        ProxyPass ws://localhost/guacamole/websocket-tunnel
+        ProxyPassReverse ws://localhost/guacamole/websocket-tunnel
+
+        # RequestHeader set REMOTE_USER guacadmin
     </Location>
 </VirtualHost>

--- a/files/guacamole_httpd_config
+++ b/files/guacamole_httpd_config
@@ -34,23 +34,20 @@
     </Location>
 
     <Location /websocket-tunnel>
-        # AuthType GSSAPI
-        # AuthName "FreeIPA Kerberos Login for Guacamole Users"
-        # GssapiCredStore keytab:/etc/krb5_http.keytab
-        # GssapiSSLonly On
-        # GssapiUseSessions On
-        # Session On
-        # SessionCookieName gssapi_session path=/admin;httponly;secure;
+        AuthType GSSAPI
+        AuthName "FreeIPA Kerberos Login for Guacamole Users"
+        GssapiCredStore keytab:/etc/krb5_http.keytab
+        GssapiSSLonly On
+        GssapiUseSessions On
+        Session On
+        SessionCookieName gssapi_session path=/websocket-tunnel;httponly;secure;
 
-        # require pam-account guacamole-admin
-
-        Order allow,deny
-        Allow from all
+        require pam-account guacamole
 
         ProxyPass ws://localhost/guacamole/websocket-tunnel
         ProxyPassReverse ws://localhost/guacamole/websocket-tunnel
 
-        # RequestHeader set REMOTE_USER guacadmin
+        RequestHeader set REMOTE_USER guacuser
     </Location>
 
     <Location /admin>
@@ -70,23 +67,20 @@
         RequestHeader set REMOTE_USER guacadmin
     </Location>
 
-    <Location /websocket-tunnel>
-        # AuthType GSSAPI
-        # AuthName "FreeIPA Kerberos Login for Guacamole Administrators"
-        # GssapiCredStore keytab:/etc/krb5_http.keytab
-        # GssapiSSLonly On
-        # GssapiUseSessions On
-        # Session On
-        # SessionCookieName gssapi_session path=/admin;httponly;secure;
+    <Location /admin/websocket-tunnel>
+        AuthType GSSAPI
+        AuthName "FreeIPA Kerberos Login for Guacamole Administrators"
+        GssapiCredStore keytab:/etc/krb5_http.keytab
+        GssapiSSLonly On
+        GssapiUseSessions On
+        Session On
+        SessionCookieName gssapi_session path=/admin/websocket-tunnel;httponly;secure;
 
-        # require pam-account guacamole-admin
-
-        Order allow,deny
-        Allow from all
+        require pam-account guacamole-admin
 
         ProxyPass ws://localhost/guacamole/websocket-tunnel
         ProxyPassReverse ws://localhost/guacamole/websocket-tunnel
 
-        # RequestHeader set REMOTE_USER guacadmin
+        RequestHeader set REMOTE_USER guacadmin
     </Location>
 </VirtualHost>


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Modifies the Apache configuration to proxy websocket connections
* Adds `flushpackets=on` to the HTTP `Proxypass` directives
* Modifies the Apache configuration to prefer `On` to `on` everywhere

## 💭 Motivation and Context

@dav3r noticed that the guacamole logs were outputting a message stating that HTTP was being used instead of websockets and performance may be degraded.  He also found [this document](https://guacamole.apache.org/doc/gug/proxying-guacamole.html#apache), which describes how to configure Apache to proxy guacamole.  This pull request contains the Apache configuration changes from that document, which allow the guacamole websocket connections to be proxied.  This results in a noticeable performance improvement.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.  The modified Apache config has been tested in env1 in our staging environment and found to greatly improve guacamole performance.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
