### PR TITLE
Update path to real username and password

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: Update dummy username/password with real values
   copy:
     content: "{{ item.contents }}"
-    dest: "/var/guacamole/secrets/{{ item.filename }}"
+    dest: "/var/guacamole/src/secrets/{{ item.filename }}"
     mode: 0664
   loop:
     - {filename: "postgres-username", contents: "{{ postgres_username }}"}


### PR DESCRIPTION
## 🗣 Description ##

I removed a redundant path in commit cisagov/guacamole-composition@16627d2 (from cisagov/guacamole-composition#21), but the redundant path is what was still being referenced by this role.

## 💭 Motivation and Context ##

This Ansible role errors out without this change, which is [preventing me](https://github.com/cisagov/guacamole-packer/runs/1689948973?check_suite_focus=true) from building new COOL Guacamole AMIs containing the changes from cisagov/guacamole-composition#21.

## 🧪 Testing ##

All `molecule` tests and `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
