### PR TITLE
Fix the docker-compose path in the guacamole-composition SystemD unit file

### DIFF
--- a/files/guacamole-composition.service
+++ b/files/guacamole-composition.service
@@ -6,11 +6,11 @@ Requires=docker.service
 [Service]
 Restart=always
 # Stop containers (if running) when unit is stopped
-ExecStartPre=/usr/local/bin/docker-compose --file /var/guacamole/docker-compose.yml down
+ExecStartPre=/usr/bin/docker-compose --file /var/guacamole/docker-compose.yml down
 # Start containers when unit is started
-ExecStart=/usr/local/bin/docker-compose --file /var/guacamole/docker-compose.yml up
+ExecStart=/usr/bin/docker-compose --file /var/guacamole/docker-compose.yml up
 # Stop container when unit is stopped
-ExecStop=/usr/local/bin/docker-compose --file /var/guacamole/docker-compose.yml down
+ExecStop=/usr/bin/docker-compose --file /var/guacamole/docker-compose.yml down
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## 🗣 Description ##

This pull request corrects the path to the `docker-compose` executable in several places in the [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition) SystemD unit file.

## 💭 Motivation and Context ##

Now that we install `docker-compose` via the system package instead of via `pip`, the path to `docker-compose` has changed.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All new and existing tests pass.
