### PR TITLE
Update to support new cisagov/guacscanner version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ None.
 | rdp_password | The password for Guacamole to use when connecting to an instance via RDP. | n/a | Yes |
 | vnc_username | The username for Guacamole to use when connecting to an instance via VNC. | n/a | Yes |
 | vnc_password | The password for Guacamole to use when connecting to an instance via VNC. | n/a | Yes |
+| windows_sftp_base | The base path for the SFTP directories that Guacamole will use when connecting to a Windows instance via VNC. | n/a | Yes |
 
 ## Dependencies ##
 
@@ -45,6 +46,7 @@ Here's how to use it in a playbook:
           rdp_password: rdp_password
           vnc_username: vnc_user
           vnc_password: vnc_password
+          windows_sftp_base: /C:/Users/vnc_user
 ```
 
 ## Contributing ##

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,3 +13,4 @@
         rdp_password: rdp_password
         vnc_username: vnc_user
         vnc_password: vnc_password
+        windows_sftp_base: /C:/Users/vnc_user

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
     - {filename: "rdp-password", contents: "{{ rdp_password }}"}
     - {filename: "vnc-username", contents: "{{ vnc_username }}"}
     - {filename: "vnc-password", contents: "{{ vnc_password }}"}
+    - {filename: "windows-sftp-base", contents: "{{ windows_sftp_base }}"}
   loop_control:
     label: "{{ item.filename }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/update/support_new_guacscanner_version
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/develop
     dest: /var/guacamole
     remote_src: yes
     extra_opts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/develop
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/update/support_new_guacscanner_version
     dest: /var/guacamole
     remote_src: yes
     extra_opts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.0-rc.1
+        - cisagov/guacscanner:1.1.0-rc.2
         - guacamole/guacd
         - guacamole/guacamole
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.0.0
+        - cisagov/guacscanner:1.1.0-rc.1
         - guacamole/guacd
         - guacamole/guacamole
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.0-rc.2
+        - cisagov/guacscanner:1.1.0
         - guacamole/guacd
         - guacamole/guacamole
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner
+        - cisagov/guacscanner:1.0.0
         - guacamole/guacd
         - guacamole/guacamole
         # The version of the JDBC PostgreSQL driver included in the


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds support for the new version of [cisagov/guacscanner] and updates the tasks to install a specific version of [cisagov/guacscanner].
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the changes in https://github.com/cisagov/guacscanner/pull/16 to connect to Windows instances using VNC there needs to be an additional secret for the [Dockerized container version](https://github.com/cisagov/guacscanner-docker) of [cisagov/guacscanner]. Additionally we specify the version of the [Dockerized container version](https://github.com/cisagov/guacscanner-docker) to install to avoid unsupported changes to a `latest` version from being unintentionally installed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests work. I generated a new AMI using this branch and everything installed and worked as expected.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Use finalized version of [cisagov/guacscanner]
- [x] Revert to the `develop` branch for pulling [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition)

[cisagov/guacscanner]: https://github.com/cisagov/guacscanner