### PR TITLE
Use the latest guacscanner Docker image

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.0
+        - cisagov/guacscanner:1.1.1-rc.1
         - guacamole/guacd
         - guacamole/guacamole
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/develop
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/use-latest-guacscanner
     dest: /var/guacamole
     remote_src: yes
     extra_opts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/use-latest-guacscanner
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/develop
     dest: /var/guacamole
     remote_src: yes
     extra_opts:
@@ -34,7 +34,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.1-rc.1
+        - cisagov/guacscanner:1.1.1
         - guacamole/guacd
         - guacamole/guacamole
         # The version of the JDBC PostgreSQL driver included in the


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies this Ansible role to make use of the latest version of [the `guacscanner` Docker image](https://github.com/cisagov/guacscanner-docker).

## 💭 Motivation and context ##

We need to build [a Guacamole AMI](https://github.com/cisagov/guacamole-packer) with the latest version of the Docker image in order to test it.

## 🧪 Testing ##

I created a new [`guacscanner` AMI](https://github.com/guacamole-packer) for our COOL staging environment with these changes and verified that it behaved as expected.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
