### PR TITLE
Pull in the latest version of the cisagov/guacscanner Docker image

### DIFF
--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -70,8 +70,19 @@ def test_apache2_unit_modification(host):
 
 @pytest.mark.parametrize(
     "image",
-    ["cisagov/guacscanner", "guacamole/guacd", "guacamole/guacamole", "postgres"],
+    [
+        "cisagov/guacscanner:1.1.6",
+        "guacamole/guacd:latest",
+        "guacamole/guacamole:latest",
+        "postgres:13",
+    ],
 )
 def test_docker_images_pulled(host, image):
     """Test that the Docker images used by the Guacamole Docker composition are present."""
-    assert image in host.check_output("docker images")
+    assert image in host.check_output(
+        # Unfortunately Jinja and Go templates use the same
+        # double-bracket syntax, so we have to force Jinja to ignore
+        # it so the Go template gets passed along to the docker
+        # command.
+        "docker images --format='{% raw %}{{.Repository}}:{{.Tag}}{% endraw %}'"
+    )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.1
+        - cisagov/guacscanner:1.1.6
         - guacamole/guacd
         - guacamole/guacamole
         # The version of the JDBC PostgreSQL driver included in the


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to pull in the latest version of the [cisagov/guacscanner](https://github.com/guacscanner) [Docker image](https://github.com/cisagov/guacscanner-docker).

## 💭 Motivation and context ##

This role is applied to AMIs that run on EC2 instances that do not have internet access, so we need to pull down the same version of the Docker image that is used in [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition).

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.