### PR TITLE
Update the Docker image versions that are pulled down

### DIFF
--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -71,9 +71,9 @@ def test_apache2_unit_modification(host):
 @pytest.mark.parametrize(
     "image",
     [
-        "cisagov/guacscanner:1.1.6",
-        "guacamole/guacd:latest",
-        "guacamole/guacamole:latest",
+        "cisagov/guacscanner:1.1.11",
+        "guacamole/guacd:1.4.0",
+        "guacamole/guacamole:1.4.0",
         "postgres:13",
     ],
 )

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,9 +44,11 @@
         - guacamole/guacd:1.4.0
         - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the
-        # Guacamole Docker image (the one tagged "latest", as of
-        # November 5, 2021) is too old to work with PostgreSQL 14 or
-        # later.
+        # Guacamole Docker image (the one tagged "1.4.0") is too old
+        # to work with PostgreSQL 14 or later.
+        #
+        # See cisagov/guacamole-composition#37 for more information as
+        # to when this limitation can be remedied.
         - postgres:13
 
 - name: Update dummy username/password with real values

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,12 @@
       - "--strip-components=1"
     creates: /var/guacamole/docker-compose.yml
 
+- name: Create the dbinit directory with the desired permissions
+  ansible.builtin.file:
+    mode: 0777
+    path: /var/guacamole/dbinit
+    state: directory
+
 - name: Pull the Docker images used by the Guacamole Docker composition
   block:
     # Docker is only enabled in ansible-role-docker, but we need it to

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,9 +34,9 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.6
-        - guacamole/guacd
-        - guacamole/guacamole
+        - cisagov/guacscanner:1.1.11
+        - guacamole/guacd:1.4.0
+        - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the
         # Guacamole Docker image (the one tagged "latest", as of
         # November 5, 2021) is too old to work with PostgreSQL 14 or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/improvement/pin-docker-image-versions
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/develop
     dest: /var/guacamole
     remote_src: yes
     extra_opts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,9 @@
 # tasks file for guacamole
 - name: Create the /var/guacamole directory
   ansible.builtin.file:
+    mode: 0755
     path: /var/guacamole
     state: directory
-    mode: 0755
 
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/develop
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/improvement/pin-docker-image-versions
     dest: /var/guacamole
     remote_src: yes
     extra_opts:


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the versions of the Docker images that are pulled down to match those being used in [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition).

## 💭 Motivation and context ##

If we don't pull the same versions used in [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition) then the Docker composition won't work since the Guacamole instance does not have internet access.  It also adds a task to pre-create the `dbinit` directory with the correct permissions.

## 🧪 Testing ##

All automated testing passes.  I also built a staging AMI with these changes and verified that it functioned as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.