### PR TITLE
Use the latest version of the Guacamole Docker composition

### DIFF
--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -71,7 +71,7 @@ def test_apache2_unit_modification(host):
 @pytest.mark.parametrize(
     "image",
     [
-        "cisagov/guacscanner:1.1.13-rc.3",
+        "cisagov/guacscanner:1.1.13-rc.4",
         "guacamole/guacd:1.4.0",
         "guacamole/guacamole:1.4.0",
         "postgres:13",

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -71,7 +71,7 @@ def test_apache2_unit_modification(host):
 @pytest.mark.parametrize(
     "image",
     [
-        "cisagov/guacscanner:1.1.13-rc.2",
+        "cisagov/guacscanner:1.1.13-rc.3",
         "guacamole/guacd:1.4.0",
         "guacamole/guacamole:1.4.0",
         "postgres:13",

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -71,7 +71,7 @@ def test_apache2_unit_modification(host):
 @pytest.mark.parametrize(
     "image",
     [
-        "cisagov/guacscanner:1.1.13-rc.4",
+        "cisagov/guacscanner:1.1.13-rc.5",
         "guacamole/guacd:1.4.0",
         "guacamole/guacamole:1.4.0",
         "postgres:13",

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -71,7 +71,7 @@ def test_apache2_unit_modification(host):
 @pytest.mark.parametrize(
     "image",
     [
-        "cisagov/guacscanner:1.1.13-rc.1",
+        "cisagov/guacscanner:1.1.13-rc.2",
         "guacamole/guacd:1.4.0",
         "guacamole/guacamole:1.4.0",
         "postgres:13",

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -71,7 +71,7 @@ def test_apache2_unit_modification(host):
 @pytest.mark.parametrize(
     "image",
     [
-        "cisagov/guacscanner:1.1.13-rc.5",
+        "cisagov/guacscanner:1.1.13",
         "guacamole/guacd:1.4.0",
         "guacamole/guacamole:1.4.0",
         "postgres:13",

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -71,7 +71,7 @@ def test_apache2_unit_modification(host):
 @pytest.mark.parametrize(
     "image",
     [
-        "cisagov/guacscanner:1.1.11",
+        "cisagov/guacscanner:1.1.13-rc.1",
         "guacamole/guacd:1.4.0",
         "guacamole/guacamole:1.4.0",
         "postgres:13",

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/improvement/use-the-latest-version-of-guacscanner
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4-rc.2
     dest: /var/guacamole
     remote_src: yes
     extra_opts:
@@ -40,7 +40,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.13-rc.1
+        - cisagov/guacscanner:1.1.13-rc.2
         - guacamole/guacd:1.4.0
         - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.11
+        - cisagov/guacscanner:1.1.13-rc.1
         - guacamole/guacd:1.4.0
         - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4-rc.2
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4-rc.3
     dest: /var/guacamole
     remote_src: yes
     extra_opts:
@@ -40,7 +40,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.13-rc.2
+        - cisagov/guacscanner:1.1.13-rc.3
         - guacamole/guacd:1.4.0
         - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/develop
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/improvement/use-the-latest-version-of-guacscanner
     dest: /var/guacamole
     remote_src: yes
     extra_opts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4-rc.5
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4
     dest: /var/guacamole
     remote_src: yes
     extra_opts:
@@ -40,7 +40,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.13-rc.5
+        - cisagov/guacscanner:1.1.13
         - guacamole/guacd:1.4.0
         - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4-rc.3
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4-rc.4
     dest: /var/guacamole
     remote_src: yes
     extra_opts:
@@ -40,7 +40,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.13-rc.3
+        - cisagov/guacscanner:1.1.13-rc.4
         - guacamole/guacd:1.4.0
         - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4-rc.4
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4-rc.5
     dest: /var/guacamole
     remote_src: yes
     extra_opts:
@@ -40,7 +40,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.13-rc.4
+        - cisagov/guacscanner:1.1.13-rc.5
         - guacamole/guacd:1.4.0
         - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the code to use the latest version of the Guacamole Docker composition.

## 💭 Motivation and context ##

The latest version of the Guacamole Docker composition uses the latest version of the `cisagov/guacscanner` Docker image, which itself includes the following updates to the [cisagov/guacscanner](https://github.com/cisagov/guacscanner) repository:
- cisagov/guacscanner#32
- cisagov/guacscanner#33

## 🧪 Testing ##

Automated testing passes.  I also created a new COOL staging AMI from these changes and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert dependencies to default branches.