### PR TITLE
Update code to use the "docker compose" syntax vice "docker-compose"

### DIFF
--- a/files/guacamole-composition.service
+++ b/files/guacamole-composition.service
@@ -6,11 +6,11 @@ Requires=docker.service
 [Service]
 Restart=always
 # Stop containers (if running) when unit is stopped
-ExecStartPre=/usr/bin/docker-compose --file /var/guacamole/docker-compose.yml down
+ExecStartPre=/usr/bin/docker compose --file /var/guacamole/docker-compose.yml down
 # Start containers when unit is started
-ExecStart=/usr/bin/docker-compose --file /var/guacamole/docker-compose.yml up
+ExecStart=/usr/bin/docker compose --file /var/guacamole/docker-compose.yml up
 # Stop container when unit is stopped
-ExecStop=/usr/bin/docker-compose --file /var/guacamole/docker-compose.yml down
+ExecStop=/usr/bin/docker compose --file /var/guacamole/docker-compose.yml down
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the code to use the `docker compose` syntax instead of the `docker-compose` syntax.

## 💭 Motivation and context ##

The `docker compose` syntax is the preferred (and only correct) syntax after the changes in cisagov/ansible-role-docker#60.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.