### PR TITLE
Install the latest version of the Guacamole Docker composition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -71,7 +71,7 @@ def test_apache2_unit_modification(host):
 @pytest.mark.parametrize(
     "image",
     [
-        "cisagov/guacscanner:1.1.13",
+        "cisagov/guacscanner:1.1.15",
         "guacamole/guacd:1.4.0",
         "guacamole/guacamole:1.4.0",
         "postgres:13",

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.4
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.5
     dest: /var/guacamole
     remote_src: yes
     extra_opts:
@@ -40,7 +40,7 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - cisagov/guacscanner:1.1.13
+        - cisagov/guacscanner:1.1.15
         - guacamole/guacd:1.4.0
         - guacamole/guacamole:1.4.0
         # The version of the JDBC PostgreSQL driver included in the


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to use the latest version of the Guacamole Docker composition.

## 💭 Motivation and context ##

The latest version of the Docker composition uses the latest version of the [cisagov/guacscanner](https://github.com/cisagov/guacscanner) Docker image.  This newer Docker image should function identically to the old one, but with potentially better performance.  See the following PRs for more details:
- cisagov/guacscanner#68
- cisagov/guacscanner#94
- cisagov/guacscanner#96
- cisagov/guacscanner-docker#20
- cisagov/guacscanner-docker#21
- cisagov/guacamole-composition#52

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.