### PR TITLE
Use the latest version of cisagov/guacamole-composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
+| guacamole_composition_version | The version of [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition) to use. | `0.1.6` | No |
 | postgres_username | The username to use when connecting to the PostgreSQL database that backends Guacamole. | n/a | Yes |
 | postgres_password | The password to use when connecting to the PostgreSQL database that backends Guacamole. | n/a | Yes |
 | private_ssh_key | The private ssh key to use for SFTP file transfer in Guacamole. | n/a | Yes |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# The version of cisagov/guacamole-composition to use
+guacamole_composition_version: 0.1.6

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Download and untar the guacamole-composition tarball
   ansible.builtin.unarchive:
     src: >
-      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v0.1.5
+      https://api.github.com/repos/cisagov/guacamole-composition/tarball/v{{ guacamole_composition_version }}
     dest: /var/guacamole
     remote_src: yes
     extra_opts:


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Modifies the Ansible role to install the latest version of [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition)
- Adds a role variable to allow the user to specify the version of [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition) to use.  The default value is currently set to the latest version of [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition).

## 💭 Motivation and context ##

The latest version of [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition) enforces a maximum size for Docker logs.  See cisagov/guacamole-composition#54 and cisagov/guacamole-composition#55 for more details.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.