### PR TITLE
Update to use the latest version of cisagov/guacamole-composition

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # The version of cisagov/guacamole-composition to use
-guacamole_composition_version: 0.1.7-rc.4
+guacamole_composition_version: 1.0.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # The version of cisagov/guacamole-composition to use
-guacamole_composition_version: 0.1.6
+guacamole_composition_version: 0.1.7-rc.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # The version of cisagov/guacamole-composition to use
-guacamole_composition_version: 0.1.7-rc.3
+guacamole_composition_version: 0.1.7-rc.4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # The version of cisagov/guacamole-composition to use
-guacamole_composition_version: 0.1.7-rc.1
+guacamole_composition_version: 0.1.7-rc.2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # The version of cisagov/guacamole-composition to use
-guacamole_composition_version: 0.1.7-rc.2
+guacamole_composition_version: 0.1.7-rc.3

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -72,8 +72,8 @@ def test_apache2_unit_modification(host):
     "image",
     [
         "cisagov/guacscanner:1.1.15",
-        "guacamole/guacd:1.4.0",
-        "guacamole/guacamole:1.4.0",
+        "guacamole/guacd:1.5.0",
+        "guacamole/guacamole:1.5.0",
         "postgres:13",
     ],
 )

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -74,7 +74,7 @@ def test_apache2_unit_modification(host):
         "cisagov/guacscanner:1.1.15",
         "guacamole/guacd:1.5.1",
         "guacamole/guacamole:1.5.1",
-        "postgres:13",
+        "postgres:15",
     ],
 )
 def test_docker_images_pulled(host, image):

--- a/molecule/tests/test_default.py
+++ b/molecule/tests/test_default.py
@@ -72,8 +72,8 @@ def test_apache2_unit_modification(host):
     "image",
     [
         "cisagov/guacscanner:1.1.15",
-        "guacamole/guacd:1.5.0",
-        "guacamole/guacamole:1.5.0",
+        "guacamole/guacd:1.5.1",
+        "guacamole/guacamole:1.5.1",
         "postgres:13",
     ],
 )

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,8 @@
 ansible>=2.10,<6
 ansible-lint>=5,<6
 flake8
-molecule[docker]
+molecule
+molecule-plugins[docker]
 pre-commit
 pytest-testinfra
 yamllint

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,8 +41,8 @@
         source: pull
       loop:
         - cisagov/guacscanner:1.1.15
-        - guacamole/guacd:1.5.1
         - guacamole/guacamole:1.5.1
+        - guacamole/guacd:1.5.1
         - postgres:15
 
 - name: Update dummy username/password with real values

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,13 +43,7 @@
         - cisagov/guacscanner:1.1.15
         - guacamole/guacd:1.5.1
         - guacamole/guacamole:1.5.1
-        # The version of the JDBC PostgreSQL driver included in the
-        # Guacamole Docker image (the one tagged "1.4.0") is too old
-        # to work with PostgreSQL 14 or later.
-        #
-        # See cisagov/guacamole-composition#37 for more information as
-        # to when this limitation can be remedied.
-        - postgres:13
+        - postgres:15
 
 - name: Update dummy username/password with real values
   ansible.builtin.copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,8 +41,8 @@
         source: pull
       loop:
         - cisagov/guacscanner:1.1.15
-        - guacamole/guacd:1.4.0
-        - guacamole/guacamole:1.4.0
+        - guacamole/guacd:1.5.0
+        - guacamole/guacamole:1.5.0
         # The version of the JDBC PostgreSQL driver included in the
         # Guacamole Docker image (the one tagged "1.4.0") is too old
         # to work with PostgreSQL 14 or later.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,8 +41,8 @@
         source: pull
       loop:
         - cisagov/guacscanner:1.1.15
-        - guacamole/guacd:1.5.0
-        - guacamole/guacamole:1.5.0
+        - guacamole/guacd:1.5.1
+        - guacamole/guacamole:1.5.1
         # The version of the JDBC PostgreSQL driver included in the
         # Guacamole Docker image (the one tagged "1.4.0") is too old
         # to work with PostgreSQL 14 or later.


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible role to use the latest version of [cisagov/guacamole-composition](https://github.com/cisagov/guacamole-composition), which in turn uses the latest releases (i.e., the 1.5 releases) of the [guacamole/guacamole](https://hub.docker.com/r/guacamole/guacamole) and [guacamole/guacd](https://hub.docker.com/r/guacamole/guacd) Docker containers.

## 💭 Motivation and context ##

See cisagov/guacamole-composition#58.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.