### PR TITLE
Make string an f-string

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -94,7 +94,7 @@ def test_unit_properties(host, prop, regex):
     """Test that unit properties were modified via drop-ins as expected."""
     cmd = f"systemctl show --no-pager --property={prop} apache2.service"
     cmd_result = host.run(cmd)
-    assert cmd_result.rc == 0, "{cmd} command failed"
+    assert cmd_result.rc == 0, f"{cmd} command failed"
     assert (
         re.search(regex, cmd_result.stdout) is not None
     ), f"Regex {regex} does not match any line in {cmd} output."


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a bug in some test code where an f-string was not designated as such.

## 💭 Motivation and context ##

If the test were to fail, this error would result in an unhelpful message being output.  We may as well fix it.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.